### PR TITLE
New annotator for the topic's current lock status

### DIFF
--- a/src/SemanticMediaWiki/AnnotatorStore.php
+++ b/src/SemanticMediaWiki/AnnotatorStore.php
@@ -26,6 +26,7 @@ use SemanticStructuredDiscussions\SemanticMediaWiki\Annotators\ReplyAnnotators\C
 use SemanticStructuredDiscussions\SemanticMediaWiki\Annotators\ReplyAnnotators\ModificationDateAnnotator as ReplyModificationDateAnnotator;
 use SemanticStructuredDiscussions\SemanticMediaWiki\Annotators\ReplyAnnotators\ReplyAnnotator;
 use SemanticStructuredDiscussions\SemanticMediaWiki\Annotators\TopicAnnotators\CreatorAnnotator as TopicCreatorAnnotator;
+use SemanticStructuredDiscussions\SemanticMediaWiki\Annotators\TopicAnnotators\LockStatusAnnotator as TopicLockStatusAnnotator;
 use SemanticStructuredDiscussions\SemanticMediaWiki\Annotators\TopicAnnotators\ModificationDateAnnotator as TopicModificationDateAnnotator;
 use SemanticStructuredDiscussions\SemanticMediaWiki\Annotators\TopicAnnotators\OwnerAnnotation as TopicOwnerAnnotation;
 use SemanticStructuredDiscussions\SemanticMediaWiki\Annotators\TopicAnnotators\SummaryAnnotator as TopicSummaryAnnotator;
@@ -38,6 +39,7 @@ use SemanticStructuredDiscussions\StructuredDiscussions\SDTopic;
 class AnnotatorStore {
 	private const TOPIC_ANNOTATORS = [
 		TopicCreatorAnnotator::class,
+		TopicLockStatusAnnotator::class,
 		TopicModificationDateAnnotator::class,
 		TopicOwnerAnnotation::class,
 		TopicSummaryAnnotator::class,

--- a/src/SemanticMediaWiki/Annotators/TopicAnnotators/LockStatusAnnotator.php
+++ b/src/SemanticMediaWiki/Annotators/TopicAnnotators/LockStatusAnnotator.php
@@ -1,0 +1,70 @@
+<?php declare( strict_types=1 );
+/**
+ * Semantic Structured Discussions MediaWiki extension
+ * Copyright (C) 2022  Wikibase Solutions
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SemanticStructuredDiscussions\SemanticMediaWiki\Annotators\TopicAnnotators;
+
+use SMW\DIProperty;
+use SMW\SemanticData;
+use SMWDIBlob;
+
+/**
+ * This annotation indicates whether a topic is currently locked (true/false).
+ */
+class LockStatusAnnotator extends TopicAnnotator {
+	/**
+	 * @inheritDoc
+	 */
+	public function addAnnotation( SemanticData $semanticData ): void {
+		if ( $this->topic->getLockStatus() === null ) {
+			return;
+		}
+
+		$semanticData->addPropertyObjectValue(
+			new DIProperty( self::getId() ),
+			new SMWDIBlob( $this->topic->getLockStatus() )
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function getId(): string {
+		return '__sd_topic_is_locked';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function getLabel(): string {
+		return 'Topic is locked';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static function getDefinition(): array {
+		return [
+			'label' => self::getLabel(),
+			'type' => '_txt',
+			'viewable' => true,
+			'annotable' => false
+		];
+	}
+}

--- a/src/SemanticMediaWiki/Annotators/TopicAnnotators/LockStatusAnnotator.php
+++ b/src/SemanticMediaWiki/Annotators/TopicAnnotators/LockStatusAnnotator.php
@@ -32,10 +32,6 @@ class LockStatusAnnotator extends TopicAnnotator {
 	 * @inheritDoc
 	 */
 	public function addAnnotation( SemanticData $semanticData ): void {
-		if ( $this->topic->getLockStatus() === null ) {
-			return;
-		}
-
 		$semanticData->addPropertyObjectValue(
 			new DIProperty( self::getId() ),
 			new SMWDIBlob( $this->topic->getLockStatus() )

--- a/src/SemanticMediaWiki/Annotators/TopicAnnotators/LockStatusAnnotator.php
+++ b/src/SemanticMediaWiki/Annotators/TopicAnnotators/LockStatusAnnotator.php
@@ -34,7 +34,7 @@ class LockStatusAnnotator extends TopicAnnotator {
 	public function addAnnotation( SemanticData $semanticData ): void {
 		$semanticData->addPropertyObjectValue(
 			new DIProperty( self::getId() ),
-			new SMWDIBlob( $this->topic->getLockStatus() )
+			new SMWDIBoolean( $this->topic->getLockStatus() )
 		);
 	}
 
@@ -58,7 +58,7 @@ class LockStatusAnnotator extends TopicAnnotator {
 	public static function getDefinition(): array {
 		return [
 			'label' => self::getLabel(),
-			'type' => '_txt',
+			'type' => '_boo',
 			'viewable' => true,
 			'annotable' => false
 		];

--- a/src/StructuredDiscussions/SDTopic.php
+++ b/src/StructuredDiscussions/SDTopic.php
@@ -117,8 +117,8 @@ final class SDTopic {
 	 *
 	 * @return string
 	 */
-	public function getLockStatus(): string {
-		return var_export($this->getRootRevision()['isLocked'], true);		
+	public function getLockStatus(): bool {
+		return $this->getRootRevision()['isLocked'];		
 	}
 
 	/**

--- a/src/StructuredDiscussions/SDTopic.php
+++ b/src/StructuredDiscussions/SDTopic.php
@@ -113,6 +113,15 @@ final class SDTopic {
 	}
 
 	/**
+	 * Returns the topic's current lock state.
+	 *
+	 * @return string
+	 */
+	public function getLockStatus(): string {
+		return var_export($this->getRootRevision()['isLocked'], true);		
+	}
+
+	/**
 	 * Returns true if any user that is able to view the topic owner is also able to view this topic.
 	 * This is not always the case, since a topic can be hidden, suppressed or deleted.
 	 *


### PR DESCRIPTION
These commits add a new annotator for the topic's current lock state, an idea that was initially proposed and discussed over on the [MediaWiki extension page](https://www.mediawiki.org/wiki/Topic:X7ebn8dd75ccgb8f). The addition works as intended on my MW install. Nevertheless, please review thoroughly as I'm a beginner developer who has very limited experience at this stage.

Although I believe the appropriate type for the lock state property is boolean, it's currently set to type string because I was unable to figure out how to make it boolean. During my attempts I've changed various definitions but apparently missed one or multiple, since smw's rebuildData.php script kept saying that "Return value of ~\SDTopic::getLockStatus() must be of the type string, bool returned".
