### PR TITLE
Call the correct class in LockStatusAnnotator.php (SMWDIBoolean)

### DIFF
--- a/src/SemanticMediaWiki/Annotators/TopicAnnotators/LockStatusAnnotator.php
+++ b/src/SemanticMediaWiki/Annotators/TopicAnnotators/LockStatusAnnotator.php
@@ -22,7 +22,7 @@ namespace SemanticStructuredDiscussions\SemanticMediaWiki\Annotators\TopicAnnota
 
 use SMW\DIProperty;
 use SMW\SemanticData;
-use SMWDIBlob;
+use SMWDIBoolean;
 
 /**
  * This annotation indicates whether a topic is currently locked (true/false).


### PR DESCRIPTION
This commit fixes the SMW class called by LockStatusAnnotator (updated from Blob to Boolean).

@ Marijn looks like we forgot this one earlier :relaxed: