### PR TITLE
Change datatype of OwnerNamespaceAnnotation to _keyw from _num

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
 	"name": "Semantic Structured Discussions",
 	"type": "semantic",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"author": [
 		"Marijn van Wezel ([https://wikibase-solutions.com Wikibase Solutions])"
 	],

--- a/src/SemanticMediaWiki/Annotators/TopicAnnotators/OwnerNamespaceAnnotation.php
+++ b/src/SemanticMediaWiki/Annotators/TopicAnnotators/OwnerNamespaceAnnotation.php
@@ -78,7 +78,7 @@ class OwnerNamespaceAnnotation extends TopicAnnotator {
 	public static function getDefinition(): array {
 		return [
 			'label' => self::getLabel(),
-			'type' => '_num',
+			'type' => '_keyw',
 			'viewable' => true,
 			'annotable' => true
 		];

--- a/src/SemanticMediaWiki/Annotators/TopicAnnotators/OwnerNamespaceAnnotation.php
+++ b/src/SemanticMediaWiki/Annotators/TopicAnnotators/OwnerNamespaceAnnotation.php
@@ -25,7 +25,7 @@ use Flow\Exception\InvalidInputException;
 use MediaWiki\MediaWikiServices;
 use SMW\DIProperty;
 use SMW\SemanticData;
-use SMWDINumber;
+use SMW\DataValues\KeywordValue;
 use Title;
 
 /**
@@ -52,9 +52,12 @@ class OwnerNamespaceAnnotation extends TopicAnnotator {
 			$topicArticle = Title::newFromLinkTarget( $topicArticle );
 		}
 
+		$value = new KeywordValue();
+		$value->setUserValue( $topicArticle->getNamespace() );
+
 		$semanticData->addPropertyObjectValue(
 			new DIProperty( self::getId() ),
-			new SMWDINumber( $topicArticle->getNamespace() )
+			$value->getDataItem()
 		);
 	}
 


### PR DESCRIPTION
Namespace number are not numbers in the sense that operations like < or > or + or - or * make sense.

Also see https://www.elastic.co/guide/en/elasticsearch/reference/current/number.html (jan 2022) which states:

Not all numeric data should be mapped as a numeric field data type. Elasticsearch optimizes numeric fields, such as integer or long, for range queries. However, keyword fields are better for term and other term-level queries.