### PR TITLE
Import existing data from reply subobjects

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
 	"name": "Semantic Structured Discussions",
 	"type": "semantic",
-	"version": "1.7.0",
+	"version": "1.7.1",
 	"author": [
 		"Marijn van Wezel ([https://wikibase-solutions.com Wikibase Solutions])"
 	],

--- a/src/SemanticMediaWiki/DataAnnotator.php
+++ b/src/SemanticMediaWiki/DataAnnotator.php
@@ -74,9 +74,19 @@ class DataAnnotator {
 				continue;
 			}
 
-			$subobject = new Subobject( $semanticData->getSubject()->getTitle() );
-			$subobject->setEmptyContainerForId( sprintf( 'flow-post-%s', $reply->getPostId() ) );
+			$id = sprintf( 'flow-post-%s', $reply->getPostId() );
 
+			// Create a new subobject to hold the semantic data
+			$subobject = new Subobject( $semanticData->getSubject()->getTitle() );
+			$subobject->setEmptyContainerForId( $id );
+
+			$existingData = $semanticData->findSubSemanticData( $id );
+			if ( $existingData !== null ) {
+				// Import any existing data into the subobject, so that we do not override that
+				$subobject->getSemanticData()->importDataFrom( $existingData );
+			}
+
+			// Override or add the new reply annotations
 			$this->addReplyAnnotations( $reply, $subobject->getSemanticData(), $topic );
 
 			$semanticData->addSubobject( $subobject );


### PR DESCRIPTION
This pull request, when merges, fixes an issue where subobject data that was already present would be overridden by SSD. In this new version, it first fetches the existing subobject data, then adds the new properties onto that, instead of creating an entirely new SemanticData object.