### PR TITLE
Do not add annotations on topics related to deleted/non-existent pages

### DIFF
--- a/src/SemanticMediaWiki/DataAnnotator.php
+++ b/src/SemanticMediaWiki/DataAnnotator.php
@@ -50,8 +50,9 @@ class DataAnnotator {
 	 * @param SemanticData $semanticData The SemanticData object to add the annotations to
 	 */
 	public function addAnnotations( SDTopic $topic, SemanticData $semanticData ): void {
-		if ( !$topic->isEveryoneAllowed() ) {
+		if ( !$topic->isEveryoneAllowed() || !$topic->getTopicOwner()->exists() ) {
 			// Do not annotate the topic if it is not viewable by everyone, since this WILL lead to information leakage
+			// Do not annotate if parent page does not exist; the topic should then be removed as well
 			return;
 		}
 


### PR DESCRIPTION
Because you do not want that.

Question: When page is deleted, should we then update the related Topic pages from inside this extension?