### PR TITLE
Do not delete page if parent subject page does not exist

### DIFF
--- a/src/SemanticMediaWiki/DataAnnotator.php
+++ b/src/SemanticMediaWiki/DataAnnotator.php
@@ -50,7 +50,7 @@ class DataAnnotator {
 	 * @param SemanticData $semanticData The SemanticData object to add the annotations to
 	 */
 	public function addAnnotations( SDTopic $topic, SemanticData $semanticData ): void {
-		if ( !$topic->isEveryoneAllowed() || !$topic->getTopicOwner()->exists() ) {
+		if ( !$topic->isEveryoneAllowed() || !$topic->getTopicOwner()->getSubjectPage()->exists() ) {
 			// Do not annotate the topic if it is not viewable by everyone, since this WILL lead to information leakage
 			// Do not annotate if parent page does not exist; the topic should then be removed as well
 			return;


### PR DESCRIPTION
see https://github.com/WikibaseSolutions/SemanticStructuredDiscussions/pull/10
It turns out, ~~SSD does clean up discussions if the talk page is deleted~~ (EDIT: No it does not do that either), but not if the subject page is deleted.

We do not want properties of topics/comments of pages saved when the subject page is deleted.

See KHUB 1461