### PR TITLE
Rebuild on page change

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -23,12 +23,6 @@
 			"i18n"
 		]
 	},
-	"config": {
-		"SemanticStructuredDiscussionsRebuildOnPageChange": {
-			"value": false,
-			"description": "Should the corresponding topic namespace be rebuild when the owner page has changed?"
-		}
-	},
 	"AutoloadNamespaces": {
 		"SemanticStructuredDiscussions\\": "src/"
 	},

--- a/extension.json
+++ b/extension.json
@@ -23,6 +23,12 @@
 			"i18n"
 		]
 	},
+	"config": {
+		"SemanticStructuredDiscussionsRebuildOnPageChange": {
+			"value": false,
+			"description": "Should the corresponding topic namespace be rebuild when the owner page has changed?"
+		}
+	},
 	"AutoloadNamespaces": {
 		"SemanticStructuredDiscussions\\": "src/"
 	},
@@ -30,13 +36,14 @@
 		"SemanticStructuredDiscussionsMagic": "i18n/SemanticStructuredDiscussions.i18n.php"
 	},
 	"ServiceWiringFiles": [
-	    "SemanticStructuredDiscussions.ServiceWiring.php"
+		"SemanticStructuredDiscussions.ServiceWiring.php"
 	],
 	"Hooks": {
 		"APIFlowAfterExecute": "SemanticStructuredDiscussions\\Hooks::onAPIFlowAfterExecute",
 		"UserGetReservedNames": "SemanticStructuredDiscussions\\Hooks::onUserGetReservedNames",
 		"SMW::Property::initProperties": "SemanticStructuredDiscussions\\Hooks::onInitProperties",
-		"SMW::Store::BeforeDataUpdateComplete": "SemanticStructuredDiscussions\\Hooks::onBeforeDataUpdateComplete"
+		"SMW::Store::BeforeDataUpdateComplete": "SemanticStructuredDiscussions\\Hooks::onBeforeDataUpdateComplete",
+		"SMW::Store::AfterDataUpdateComplete": "SemanticStructuredDiscussions\\Hooks::onAfterDataUpdateComplete"
 	},
 	"callback": "SemanticStructuredDiscussions\\Hooks::onRegisterExtension",
 	"load_composer_autoloader": true,

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -86,6 +86,14 @@ final class Hooks {
 		Services::getDataAnnotator()->addAnnotations( $topic, $semanticData );
 	}
 
+	/**
+	 * Hook to process information after an update has been completed.
+	 *
+	 * @param Store $store
+	 * @param SemanticData $semanticData
+	 * @return void
+	 * @link https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/docs/technical/hooks/hook.store.afterdataupdatecomplete.md
+	 */
 	public static function onAfterDataUpdateComplete( Store $store, SemanticData $semanticData ): void {
 		$title = $semanticData->getSubject()->getTitle();
 
@@ -100,7 +108,10 @@ final class Hooks {
 		}
 
 		foreach ( $topics as $topic ) {
-			self::rebuildForPage( $topic->getTopicTitle()->getPrefixedText() );
+			$title = $topic->getTopicTitle();
+			if ( $title ) {
+				self::rebuildForPage( $title );
+			}
 		}
 	}
 
@@ -145,7 +156,7 @@ final class Hooks {
 	/**
 	 * This method is used to reserve the usernames of the system user(s) used by this extension
 	 *
-	 * @link onUserGetReservedNames
+	 * @link https://www.mediawiki.org/wiki/Manual:Hooks/UserGetReservedNames
 	 */
 	public static function onUserGetReservedNames( &$reservedUsernames ): void {
 		$reservedUsernames []= 'SemanticStructuredDiscussions system user';

--- a/src/SemanticMediaWiki/DataAnnotator.php
+++ b/src/SemanticMediaWiki/DataAnnotator.php
@@ -51,7 +51,7 @@ class DataAnnotator {
 	 */
 	public function addAnnotations( SDTopic $topic, SemanticData $semanticData ): void {
 		$owner = $topic->getTopicOwner();
-		if ( !$topic->isEveryoneAllowed() || !$owner || !$owner->exists() || !$owner->getSubjectPage()->exists() ) {
+		if ( !$topic->isEveryoneAllowed() || !$owner->exists() || !$owner->getSubjectPage()->exists() ) {
 			// Do not annotate the topic if it is not viewable by everyone, since this WILL lead to information leakage
 			// Do not annotate if parent page (subject or talk) does not exist; the topic should then be removed as well
 			return;

--- a/src/SemanticMediaWiki/DataAnnotator.php
+++ b/src/SemanticMediaWiki/DataAnnotator.php
@@ -51,7 +51,7 @@ class DataAnnotator {
 	 */
 	public function addAnnotations( SDTopic $topic, SemanticData $semanticData ): void {
 		$owner = $topic->getTopicOwner();
-		if ( !$topic->isEveryoneAllowed() || !$owner->exists() || !$owner->getSubjectPage()->exists() ) {
+		if ( !$topic->isEveryoneAllowed() || !$owner || !$owner->exists() || !$owner->getSubjectPage()->exists() ) {
 			// Do not annotate the topic if it is not viewable by everyone, since this WILL lead to information leakage
 			// Do not annotate if parent page (subject or talk) does not exist; the topic should then be removed as well
 			return;

--- a/src/StructuredDiscussions/SDTopic.php
+++ b/src/StructuredDiscussions/SDTopic.php
@@ -162,6 +162,10 @@ final class SDTopic {
 		return $this->associatedTitle;
 	}
 
+	public function getTopicTitle(): Title {
+		return Title::makeTitleSafe( NS_TOPIC, $this->getRootPostId() );
+	}
+
 	/**
 	 * Returns the workflow of this topic.
 	 *

--- a/src/StructuredDiscussions/SDTopic.php
+++ b/src/StructuredDiscussions/SDTopic.php
@@ -162,7 +162,14 @@ final class SDTopic {
 		return $this->associatedTitle;
 	}
 
-	public function getTopicTitle(): Title {
+	/**
+	 * Returns the title of this topic.
+	 * This is the title of the "Topic page", where you get with the "permalink" button on replies.
+	 * This is different from the TopicOwner title, because that is the title of the board to which this topic belongs.
+	 *
+	 * @return Title|null Title of the topic if valid. Null if invalid (e.g. if rootPostId is empty)
+	 */
+	public function getTopicTitle(): ?Title {
 		return Title::makeTitleSafe( NS_TOPIC, $this->getRootPostId() );
 	}
 

--- a/src/StructuredDiscussions/TopicRepository.php
+++ b/src/StructuredDiscussions/TopicRepository.php
@@ -49,4 +49,28 @@ class TopicRepository {
 
 		return new SDTopic( $viewTopic['topic'] );
 	}
+
+	public function getByOwner( Title $title ): array {
+		$parameters = [ 'page' => $title->getTalkPage()->getFullText() ];
+		$topics = $this->callSubmodule( 'view-topiclist', $parameters );
+
+		$rtr = [];
+
+		if ( $topics === null ) {
+			return $rtr;
+		}
+
+		if ( !isset( $topics['topiclist'] ) ) {
+			return $rtr;
+		}
+
+		foreach ( $topics[ 'topiclist' ][ 'roots' ] as $root ) {
+			$copy = $topics[ 'topiclist' ];
+			$copy[ 'roots' ] = [ $root ];
+
+			$rtr []= new SDTopic( $copy );
+		}
+
+		return $rtr;
+	}
 }

--- a/src/StructuredDiscussions/TopicRepository.php
+++ b/src/StructuredDiscussions/TopicRepository.php
@@ -51,19 +51,23 @@ class TopicRepository {
 	}
 
 	public function getByOwner( Title $title ): array {
-		$parameters = [ 'page' => $title->getTalkPage()->getFullText() ];
+		$talkPage = $title->getTalkPageIfDefined();
+		if ( !$talkPage ) {
+			return [];
+		}
+
+		$parameters = [ 'page' => $talkPage->getFullText() ];
 		$topics = $this->callSubmodule( 'view-topiclist', $parameters );
 
-		$rtr = [];
-
 		if ( $topics === null ) {
-			return $rtr;
+			return [];
 		}
 
 		if ( !isset( $topics['topiclist'] ) ) {
-			return $rtr;
+			return [];
 		}
 
+		$rtr = [];
 		foreach ( $topics[ 'topiclist' ][ 'roots' ] as $root ) {
 			$copy = $topics[ 'topiclist' ];
 			$copy[ 'roots' ] = [ $root ];


### PR DESCRIPTION
When page owner changes or related subject page changes, rebuild the page;

You want this e.g. when you have [this pull request](https://github.com/WikibaseSolutions/SemanticStructuredDiscussions/pull/13) or if data from [this pull request](https://github.com/WikibaseSolutions/SemanticStructuredDiscussions/pull/14) depends on topic pages.