### PR TITLE
Make hook to prevent saving annotations to some topics 

### DIFF
--- a/src/SemanticMediaWiki/DataAnnotator.php
+++ b/src/SemanticMediaWiki/DataAnnotator.php
@@ -123,10 +123,19 @@ class DataAnnotator {
 	 * @param SemanticData $semanticData
 	 */
 	private function addTopicAnnotations( SDTopic $topic, SemanticData $semanticData ): void {
-		$topicAnnotators = $this->annotatorStore->getTopicAnnotators( $topic );
+		$shouldSaveTopicAnnotations = true;
+		$this->hookRunner->onSemanticStructuredDiscussionsShouldSaveTopicAnnotations(
+			$shouldSaveTopicAnnotations,
+			$topic,
+			$semanticData
+		);
 
-		foreach ( $topicAnnotators as $annotator ) {
-			$annotator->addAnnotation( $semanticData );
+		if ( $shouldSaveTopicAnnotations ) {
+			$topicAnnotators = $this->annotatorStore->getTopicAnnotators( $topic );
+
+			foreach ( $topicAnnotators as $annotator ) {
+				$annotator->addAnnotation( $semanticData );
+			}
 		}
 	}
 

--- a/src/SemanticMediaWiki/Hooks/HookRunner.php
+++ b/src/SemanticMediaWiki/Hooks/HookRunner.php
@@ -11,6 +11,7 @@ class HookRunner implements
 	SemanticStructuredDiscussionsGetReplyAnnotatorList,
 	SemanticStructuredDiscussionsGetTopicAnnotatorList,
 	SemanticStructuredDiscussionsShouldSaveReply
+	SemanticStructuredDiscussionsShouldSaveTopicAnnotations
 {
 	private HookContainer $container;
 
@@ -45,6 +46,17 @@ class HookRunner implements
 		$this->container->run(
 			'SemanticStructuredDiscussionsShouldSaveReply',
 			[ &$shouldSaveReply, $id, $index, $reply, $semanticData, $topic ]
+		);
+	}
+
+	public function onSemanticStructuredDiscussionsShouldSaveTopicAnnotations(
+		bool &$shouldSaveTopicAnnotations,
+		SDTopic $topic,
+		SemanticData $semanticData
+	): void {
+		$this->container->run(
+			'SemanticStructuredDiscussionsShouldSaveTopicAnnotations',
+			[ &$shouldSaveTopicAnnotations, $topic, $semanticData ]
 		);
 	}
 }

--- a/src/SemanticMediaWiki/Hooks/HookRunner.php
+++ b/src/SemanticMediaWiki/Hooks/HookRunner.php
@@ -10,7 +10,7 @@ use SMW\SemanticData;
 class HookRunner implements
 	SemanticStructuredDiscussionsGetReplyAnnotatorList,
 	SemanticStructuredDiscussionsGetTopicAnnotatorList,
-	SemanticStructuredDiscussionsShouldSaveReply
+	SemanticStructuredDiscussionsShouldSaveReply,
 	SemanticStructuredDiscussionsShouldSaveTopicAnnotations
 {
 	private HookContainer $container;

--- a/src/SemanticMediaWiki/Hooks/SemanticStructuredDiscussionsShouldSaveTopicAnnotations.php
+++ b/src/SemanticMediaWiki/Hooks/SemanticStructuredDiscussionsShouldSaveTopicAnnotations.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SemanticStructuredDiscussions\SemanticMediaWiki\Hooks;
+
+use SemanticStructuredDiscussions\StructuredDiscussions\SDReply;
+use SemanticStructuredDiscussions\StructuredDiscussions\SDTopic;
+use SMW\SemanticData;
+
+/**
+ * Hook that can be used to prevent annotations from being saved on some topics.
+ * The replies to the topic will be saved regardless of this hooks results
+ */
+interface SemanticStructuredDiscussionsShouldSaveTopicAnnotations {
+
+	/**
+	 * Here you can decide for some topics to not save extra annotations on them.
+	 *
+	 * @param &bool $shouldSaveTopicAnnotations If set to false, no annotations will be saved for this topic
+	 * @param SDTopic $topic The topic for which to decide if we want to save annotations
+	 * @param SemanticData $semanticData The semantic data that the topic will be saved to.
+	 *
+	 * @return void
+	 */
+	public function onSemanticStructuredDiscussionsShouldSaveTopicAnnotations(
+		bool &$shouldSaveTopicAnnotations,
+		SDTopic $topic,
+		SemanticData $semanticData
+	): void;
+}


### PR DESCRIPTION
We have a certain instance in which we do not want the topic annotations to be saved, but we do want the replies to be saved (More precisely, we want the replies to be saved that we allowed with SemanticStructuredDiscussionsShouldSaveReply)